### PR TITLE
new fixes, mostly for exploration tab

### DIFF
--- a/ShinyForestry/Matlab results/convert-bio-to-polygons-from-elicitor-and-merge-into-FullTable.R
+++ b/ShinyForestry/Matlab results/convert-bio-to-polygons-from-elicitor-and-merge-into-FullTable.R
@@ -70,7 +70,7 @@ intersection <- st_intersection(polygons_bio, polygons_jules)
 df0 <- as.data.frame(matrix(0, ncol = length(all_species_names)))
 colnames(df0) <- paste0("BioSD_", all_species_names)
 
-# Look at the area difference rowwise for mutate
+# Look at the Area difference rowwise for mutate
 compute_difference_area <- function(geom1, geom2) {
   diff_geom <- st_difference(geom1, geom2)
   if (!is_empty(diff_geom)) {

--- a/ShinyForestry/backend/plumber_apis.R
+++ b/ShinyForestry/backend/plumber_apis.R
@@ -120,13 +120,13 @@ function(res) {
 # ---- GENERATE_PARCELS
 # -- Expected Input
 # {
-#   "carbon": 800,
+#   "Carbon": 800,
 #   "species": 12,
 #   "species_goat_moth": 90,
 #   "species_stag_beetle": 20,
 #   "species_lichens": 2,
-#   "area": 7,
-#   "recreation": 10,
+#   "Area": 7,
+#   "Recreation": 10,
 #   "blocked_parcels": [
 #     {
 #       "parcel_id": "4fe067d1-d80d-4d33-8323-4a4403d2b4a5",
@@ -141,13 +141,13 @@ function(res) {
 
 # -- Expected Output list(values, geojson)
 # {
-#   "carbon": 852,
+#   "Carbon": 852,
 #   "species": 18,
 #   "species_goat_moth": 91,
 #   "species_stag_beetle": 22,
 #   "species_lichens": 4,
-#   "area": 5,
-#   "recreation": 16,
+#   "Area": 5,
+#   "Recreation": 16,
 # } 
 #                               parcel_id parcel_area planting_year planting_type is_available blocked_until_year is_blocked                       geometry
 # 1  bdd124e7-a162-4602-bff3-eb5e438d1440 0.022698955            NA          <NA>         TRUE                  0         NA POLYGON ((-1.756976 50.8314...
@@ -296,13 +296,13 @@ function(req, res, from_submit_button) {
   
   # Takes in:
   # {
-  #   "carbon": 852,
+  #   "Carbon": 852,
   #   "species": 18,
   #   "species_goat_moth": 91,
   #   "species_stag_beetle": 22,
   #   "species_lichens": 4,
-  #   "area": 5,
-  #   "recreation": 16,
+  #   "Area": 5,
+  #   "Recreation": 16,
   # } 
   
   # runs: submit_button()
@@ -310,13 +310,13 @@ function(req, res, from_submit_button) {
   # returns:
   # -- Expected Output list(values, geojson)
   # {
-  #   "carbon": 852,
+  #   "Carbon": 852,
   #   "species": 18,
   #   "species_goat_moth": 91,
   #   "species_stag_beetle": 22,
   #   "species_lichens": 4,
-  #   "area": 5,
-  #   "recreation": 16,
+  #   "Area": 5,
+  #   "Recreation": 16,
   # } 
   #                               parcel_id parcel_area planting_year planting_type is_available blocked_until_year is_blocked                       geometry
   # 1  bdd124e7-a162-4602-bff3-eb5e438d1440 0.022698955            NA          <NA>         TRUE                  0         NA POLYGON ((-1.756976 50.8314...
@@ -373,9 +373,9 @@ function(req, res, from_submit_button) {
   }
   #Find the target compatible strategies and assign global variable for use in other algorithms
   target_compatible_strategies <<- strategy_outcomes[ strategy_id %in% valid_strategies &
-                                                        (target_carbon - carbon)/carbon_sd < (-sqrt(alpha/(1-alpha))) &
-                                                        area < target_area & 
-                                                        (target_visits - visits)/visits_sd < (-sqrt(alpha/(1-alpha))) &
+                                                        (target_carbon - Carbon)/Carbon_sd < (-sqrt(alpha/(1-alpha))) &
+                                                        Area < target_area & 
+                                                        (target_visits - Visits)/Visits_sd < (-sqrt(alpha/(1-alpha))) &
                                                         Reduce(`&`, lapply(SPECIES, function(col) 100 * (targets_bio[[col]] - get(col)) < (-sqrt(alpha/(1-alpha))) )) ]
   if(nrow(target_compatible_strategies)>0){
     optimal_strategy_forfrontend <- target_compatible_strategies[which.max(objective)]
@@ -392,7 +392,7 @@ function(req, res, from_submit_button) {
   for_frontend <- st_sf(
     parcel_id = parcel_ids,
     geometry = FullTable$geometry,
-    parcel_area = FullTable$area,
+    parcel_area = FullTable$Area,
     planting_year = ifelse(tyears<2050,tyears,NA),
     planting_types = ifelse(tyears<2050, tspecies, NA),
     blocked_until_year = blocked_until_year,
@@ -403,9 +403,9 @@ function(req, res, from_submit_button) {
   
   payload <- optimal_strategy_forfrontend[, ..TARGETS]
   names(payload)[which(names(payload)=="All")] <- "Biodiversity"
-  names(payload)[which(names(payload)=="visits")] <- "Food_Produced"
-  names(payload)[which(names(payload)=="area")] <- "Area"
-  names(payload)[which(names(payload)=="carbon")] <- "Carbon"
+  names(payload)[which(names(payload)=="Visits")] <- "Food_Produced"
+  names(payload)[which(names(payload)=="Area")] <- "Area"
+  names(payload)[which(names(payload)=="Carbon")] <- "Carbon"
   bio_names_latin <- names(payload)[ ! names(payload)%in% c("Carbon", "Area", "Food_Produced", "Biodiversity")]
   bio_names_latin
   for(species in bio_names_latin){
@@ -526,7 +526,7 @@ function(res, which_cluster = 1) {
   for_frontend <- st_sf(
     parcel_id = parcel_ids,
     geometry = FullTable$geometry,
-    parcel_area = FullTable$area,
+    parcel_area = FullTable$Area,
     planting_year = ifelse(tyears<2050,tyears,NA),
     planting_types = ifelse(tyears<2050, tspecies, NA),
     blocked_until_year = blocked_until_year,
@@ -537,9 +537,9 @@ function(res, which_cluster = 1) {
   
   payload <- random_strategy[,..TARGETS]
   names(payload)[which(names(payload)=="All")] <- "Biodiversity"
-  names(payload)[which(names(payload)=="visits")] <- "Food_Produced"
-  names(payload)[which(names(payload)=="area")] <- "Area"
-  names(payload)[which(names(payload)=="carbon")] <- "Carbon"
+  names(payload)[which(names(payload)=="Visits")] <- "Food_Produced"
+  names(payload)[which(names(payload)=="Area")] <- "Area"
+  names(payload)[which(names(payload)=="Carbon")] <- "Carbon"
   bio_names_latin <- names(payload)[ ! names(payload)%in% c("Carbon", "Area", "Food_Produced", "Biodiversity")]
   bio_names_latin
   for(species in bio_names_latin){
@@ -593,7 +593,7 @@ function(res, slider_name) {
   for_frontend <- st_sf(
     parcel_id = parcel_ids,
     geometry = FullTable$geometry,
-    parcel_area = FullTable$area,
+    parcel_area = FullTable$Area,
     planting_year = ifelse(tyears<2050,tyears,NA),
     planting_types = ifelse(tyears<2050, tspecies, NA),
     blocked_until_year = blocked_until_year,
@@ -604,9 +604,9 @@ function(res, slider_name) {
   
   payload <- tc_samples_cluster[current_row,..TARGETS]
   names(payload)[which(names(payload)=="All")] <- "Biodiversity"
-  names(payload)[which(names(payload)=="visits")] <- "Food_Produced"
-  names(payload)[which(names(payload)=="area")] <- "Area"
-  names(payload)[which(names(payload)=="carbon")] <- "Carbon"
+  names(payload)[which(names(payload)=="Visits")] <- "Food_Produced"
+  names(payload)[which(names(payload)=="Area")] <- "Area"
+  names(payload)[which(names(payload)=="Carbon")] <- "Carbon"
   bio_names_latin <- names(payload)[ ! names(payload)%in% c("Carbon", "Area", "Food_Produced", "Biodiversity")]
   bio_names_latin
   for(species in bio_names_latin){
@@ -662,7 +662,7 @@ function(res, slider_name) {
   for_frontend <- st_sf(
     parcel_id = parcel_ids,
     geometry = FullTable$geometry,
-    parcel_area = FullTable$area,
+    parcel_area = FullTable$Area,
     planting_year = ifelse(tyears<2050,tyears,NA),
     planting_types = ifelse(tyears<2050, tspecies, NA),
     blocked_until_year = blocked_until_year,
@@ -673,9 +673,9 @@ function(res, slider_name) {
   
   payload <- tc_samples_cluster[current_row,..TARGETS]
   names(payload)[which(names(payload)=="All")] <- "Biodiversity"
-  names(payload)[which(names(payload)=="visits")] <- "Food_Produced"
-  names(payload)[which(names(payload)=="area")] <- "Area"
-  names(payload)[which(names(payload)=="carbon")] <- "Carbon"
+  names(payload)[which(names(payload)=="Visits")] <- "Food_Produced"
+  names(payload)[which(names(payload)=="Area")] <- "Area"
+  names(payload)[which(names(payload)=="Carbon")] <- "Carbon"
   bio_names_latin <- names(payload)[ ! names(payload)%in% c("Carbon", "Area", "Food_Produced", "Biodiversity")]
   bio_names_latin
   for(species in bio_names_latin){
@@ -1020,7 +1020,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
       
       Uni <- unique(AllUnits)
       # units is the list of decision units
-      FullTab <- data.frame(extent = "NoExtent", x = rep(0, length(Uni)), y = rep(0, length(Uni)), area = rep(1, length(Uni)),
+      FullTab <- data.frame(extent = "NoExtent", x = rep(0, length(Uni)), y = rep(0, length(Uni)), Area = rep(1, length(Uni)),
                             Carbon_Mean_Scenario26_TreeSpecieConifers = rep(15, length(Uni)),
                             Carbon_SD_Scenario26_TreeSpecieConifers = rep(1, length(Uni)), 
                             Carbon_Mean_Scenario26_TreeSpecieDeciduous = rep(15, length(Uni)),
@@ -1121,7 +1121,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
       
       
       INTT <- st_intersection(st_make_valid(SELECTEDSquaresconvTab), st_make_valid(FullTableCopy))
-      INTT$area <- st_area(INTT) / 1e6
+      INTT$Area <- st_area(INTT) / 1e6
       
       # Bootstrap means and standard deviations (to avoid assumptions of independence)
       # As we have sum of Gaussians, we 
@@ -1129,7 +1129,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
       for (i in 1:length(FullTableCopy$geometry)) {
         SELLLines <- INTT$idPoly == i
         SELLSqs <- INTT$idSq[SELLLines]
-        SELLWeights <- INTT$area[SELLLines]
+        SELLWeights <- INTT$Area[SELLLines]
         #    SellWeightsArr <- t(matrix(SELLWeights, length(SELLWeights), NBSIMS))
         SellWeightsArr <- (matrix(SELLWeights, length(SELLWeights), (MAXYEAR+1)))
         
@@ -1164,13 +1164,13 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
           FullTable[i,paste0("Carbon_SD_Scenario26_TreeSpecieDeciduous_PlantingYear",0:MAXYEAR)]<-sqrt(colSums((SelJulesSDsYears85*SellWeightsArr)^2))
           
           
-          FullTable$area[i] <- sum(SELLWeights)
+          FullTable$Area[i] <- sum(SELLWeights)
           
           # } else if (length(SelJulesMeans) == 1) {
           #  SimuArr <- rnorm(NBSIMS, mean = SelJulesMeans, sd = SelJulesSDs)
           # FullTable$JulesMean[i] <- sum(colMeans(SimuArr * SellWeightsArr))
           #  FullTable$JulesSD[i] <- sd(rowSums(SimuArr * SellWeightsArr))
-          #  FullTable$area[i] <- sum(SELLWeights)
+          #  FullTable$Area[i] <- sum(SELLWeights)
         } else {
           FullTable$Carbon_Mean_Scenario26_TreeSpecieConifers[i] <- 0
           FullTable$Carbon_SD_Scenario26_TreeSpecieConifers[i] <- 0
@@ -1186,7 +1186,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
           FullTable[i,paste0("Carbon_SD_Scenario26_TreeSpecieDeciduous_PlantingYear",0:MAXYEAR)]<-(MAXYEAR+1)
           
           
-          FullTable$area[i] <- sum(SELLWeights)
+          FullTable$Area[i] <- sum(SELLWeights)
         }
       }
       
@@ -1488,7 +1488,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
       # if TRUE, use the new mapping from the zonotope, otherwise the original mapping with convex projection. default TRUE
       reverse = FALSE)
     RREMBO_HYPER_PARAMETERS <- RRembo_defaults(d = 6,
-                                               D = 3 * nrow(FullTable), # area + planting_year + tree_specie per parcel
+                                               D = 3 * nrow(FullTable), # Area + planting_year + tree_specie per parcel
                                                init = list(n = 100), budget = 100,
                                                control = RREMBO_CONTROL,
                                                max_limit_log_level = MAX_LIMIT_LOG_LEVEL)
@@ -1496,7 +1496,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
     # SPECIES <- c(NAME_CONVERSION[1:2, "Specie"], "Pollinators", "All")
     # SPECIES_ENGLISH <- c(NAME_CONVERSION[1:2, "English_specie"], "Pollinators", "All")
     N_SPECIES <- length(SPECIES)
-    TARGETS <- c("carbon", SPECIES, "area", "visits")
+    TARGETS <- c("Carbon", SPECIES, "Area", "Visits")
     N_TARGETS <- length(TARGETS)
     
     if (exists("SquaresLoad", inherits = FALSE)) {
@@ -1510,7 +1510,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
     #Needed for passing strategies to and from front
     parcel_ids = paste0("id",parcel_id)
     
-    #FullTable_working corrects the issue with visits only being available for year 0
+    #FullTable_working corrects the issue with Visits only being available for year 0
     FullTable_working <- copy(FullTable_long)
     FullTable_working[, scenario := NULL]
     
@@ -1585,7 +1585,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
       } else {
         preference_weights[target] <- 1/max(strategy_outcomes[,..target])
       }
-      if(target=="area"){preference_weights[target] <- -preference_weights[target]}
+      if(target=="Area"){preference_weights[target] <- -preference_weights[target]}
     }
     notif(paste(msg, "done"), log_level = "debug")
     
@@ -1596,9 +1596,9 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
     get_slider_info <- function(){
       max_values <- strategy_outcomes[, lapply(.SD, max, na.rm=TRUE), .SDcols = TARGETS]
       names(max_values)[which(names(max_values)=="All")] <- "Biodiversity"
-      names(max_values)[which(names(max_values)=="visits")] <- "Food_Produced"
-      names(max_values)[which(names(max_values)=="area")] <- "Area"
-      names(max_values)[which(names(max_values)=="carbon")] <- "Carbon"
+      names(max_values)[which(names(max_values)=="Visits")] <- "Food_Produced"
+      names(max_values)[which(names(max_values)=="Area")] <- "Area"
+      names(max_values)[which(names(max_values)=="Carbon")] <- "Carbon"
       bio_names_latin <- names(max_values)[ ! names(max_values)%in% c("Carbon", "Area", "Food_Produced", "Biodiversity")]
       bio_names_latin
       for(species in bio_names_latin){
@@ -1698,9 +1698,9 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
       }
       
       
-      target_compatible_strategies <- strategy_outcomes[ (target_carbon - carbon)/carbon_sd < (-sqrt(alpha/(1-alpha))) &
-                                                            area < target_area & 
-                                                            (target_visits - visits)/visits_sd < (-sqrt(alpha/(1-alpha))) &
+      target_compatible_strategies <- strategy_outcomes[ (target_carbon - Carbon)/Carbon_sd < (-sqrt(alpha/(1-alpha))) &
+                                                            Area < target_area &
+                                                            (target_visits - Visits)/Visits_sd < (-sqrt(alpha/(1-alpha))) &
                                                             Reduce(`&`, lapply(SPECIES, function(col) 100 * (targets_bio[[col]] - get(col)) < (-sqrt(alpha/(1-alpha))) )) ]
       if(nrow(target_compatible_strategies)>0){
         optimal_strategy_forfrontend <- target_compatible_strategies[which.max(objective)]
@@ -1716,7 +1716,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
       for_frontend <- st_sf(
         parcel_id = parcel_ids,
         geometry = FullTable$geometry,
-        parcel_area = FullTable$area,
+        parcel_area = FullTable$Area,
         planting_year = ifelse(tyears<2050,tyears,NA),
         planting_types = ifelse(tyears<2050, tspecies, NA),
         blocked_until_year = blocked_until_year,
@@ -1727,9 +1727,9 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
       
       payload <- optimal_strategy_forfrontend[, ..TARGETS]
       names(payload)[which(names(payload)=="All")] <- "Biodiversity"
-      names(payload)[which(names(payload)=="visits")] <- "Food_Produced"
-      names(payload)[which(names(payload)=="area")] <- "Area"
-      names(payload)[which(names(payload)=="carbon")] <- "Carbon"
+      names(payload)[which(names(payload)=="Visits")] <- "Food_Produced"
+      names(payload)[which(names(payload)=="Area")] <- "Area"
+      names(payload)[which(names(payload)=="Carbon")] <- "Carbon"
       bio_names_latin <- names(payload)[ ! names(payload)%in% c("Carbon", "Area", "Food_Produced", "Biodiversity")]
       bio_names_latin
       for(species in bio_names_latin){
@@ -1751,6 +1751,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
     # target_compatible_strategies is needed in the environment, but first_strategy needs only the other variables
     msg <- "Making the target_compatible_strategies ..."
     notif(msg, log_level = "debug")
+    
     first_strategy <- get_first_strategy()
     target_compatible_strategies <- first_strategy$target_compatible_strategies
     first_strategy$target_compatible_strategies <- NULL
@@ -1768,8 +1769,8 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
     # mean = 1 / half(midpoint)
     # 2 * sd = 1 / half(midpoint)
     
-    prior_list_temp$carbon <- gamma_prior(2 / max(strategy_outcomes[,carbon]),
-                                          1 / max(strategy_outcomes[,carbon]))
+    prior_list_temp$Carbon <- gamma_prior(2 / max(strategy_outcomes[,Carbon]),
+                                          1 / max(strategy_outcomes[,Carbon]))
     
     # Species priors, similarly-derived values
     for (i in 1:length(SPECIES)) {
@@ -1781,12 +1782,12 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
     }
     
     # Area prior
-    prior_list_temp$area <- gamma_prior(- 2 / max(strategy_outcomes[,area]),
-                                        1 / max(strategy_outcomes[,area]))
+    prior_list_temp$Area <- gamma_prior(- 2 / max(strategy_outcomes[,Area]),
+                                        1 / max(strategy_outcomes[,Area]))
     
     # Visits prior
-    prior_list_temp$visits <- Normal(2 / max(strategy_outcomes[,visits]),
-                                     1 / max(strategy_outcomes[,visits]))
+    prior_list_temp$Visits <- Normal(2 / max(strategy_outcomes[,Visits]),
+                                     1 / max(strategy_outcomes[,Visits]))
     
     # Re-order the list in accordance to TARGETS vector
     prior_list <- list()

--- a/ShinyForestry/backend/plumber_apis.R
+++ b/ShinyForestry/backend/plumber_apis.R
@@ -1698,8 +1698,8 @@ function(res, MAX_LIMIT_LOG_LEVEL = "debug") {
                                     SPECIES_arg = SPECIES,
                                     SCENARIO_arg = SCENARIO,
                                     MAXYEAR_arg = MAXYEAR,
-                                    NAME_CONVERSION_arg = NAME_CONVERSION)
-    null_strategy[1,(n_parcels+1):(2*n_parcels)] <- 2050 - STARTYEAR
+                                    NAME_CONVERSION_arg = NAME_CONVERSION) # No planting means that planting_year = MAXYEAR+1 (25)
+    null_strategy[1,(n_parcels+1):(2*n_parcels)] <- MAXYEAR + 1
     notif(paste(msg, "done"), log_level = "debug")
     
     #Function to return optimal strategy from submit button

--- a/ShinyForestry/backend/plumber_apis.R
+++ b/ShinyForestry/backend/plumber_apis.R
@@ -573,6 +573,31 @@ function(res, slider_name) {
   
   # returns:
   # list(values, geojson) #see submit_strategy
+  
+  
+  if (slider_name == "Biodiversity") {
+    slider_name <- "All"
+  }
+  if (slider_name %in% c("Food Produced", "Food_Produced")) {
+    slider_name <- "Visits"
+  }
+  
+  # Goat_Moth -> Cossus_cossus
+  # Other strings are left unmodified
+  slider_name <- get_specie_from_english_specie(slider_name)
+  
+  slider_names <- c(TARGETS, "pc_1", "pc_2")
+  if (isFALSE(slider_name %in% slider_names)) {
+    res$status <- 403
+    notif(paste("Parameter in /exploration_minus must be a slider name among:", toString(slider_names)), log_level = "error")
+    return(paste("Parameter in /exploration_minus must be a slider name among:", toString(slider_names)))
+  }
+  if (slider_name %notin% colnames(tc_samples_cluster)) {
+    res$status <- 403
+    notif("Clustering not done, pc_1 and pc_2 cannot be changed", log_level = "error")
+    return("Clustering not done, pc_1 and pc_2 cannot be changed")
+  }
+  
   slider_names <- c(TARGETS, "pc_1", "pc_2")
   if (isFALSE(slider_name %in% slider_names)) {
     res$status <- 403
@@ -641,12 +666,27 @@ function(res, slider_name) {
   # returns:
   # list(values, geojson) #see submit_strategy
   
+  if (slider_name == "Biodiversity") {
+    slider_name <- "All"
+  }
+  if (slider_name %in% c("Food Produced", "Food_Produced")) {
+    slider_name <- "Visits"
+  }
+  
+  # Goat_Moth -> Cossus_cossus
+  # Other strings are left unmodified
+  slider_name <- get_specie_from_english_specie(slider_name)
   
   slider_names <- c(TARGETS, "pc_1", "pc_2")
   if (isFALSE(slider_name %in% slider_names)) {
     res$status <- 403
-    notif(paste("Parameter in /exploration_minus must be a slider name:", slider_names), log_level = "error")
-    return(paste("Parameter in /exploration_minus must be a slider name:", slider_names))
+    notif(paste("Parameter in /exploration_minus must be a slider name among:", toString(slider_names)), log_level = "error")
+    return(paste("Parameter in /exploration_minus must be a slider name among:", toString(slider_names)))
+  }
+  if (slider_name %notin% colnames(tc_samples_cluster)) {
+    res$status <- 403
+    notif("Clustering not done, pc_1 and pc_2 cannot be changed", log_level = "error")
+    return("Clustering not done, pc_1 and pc_2 cannot be changed")
   }
   
   setorderv(tc_samples_cluster, slider_name, order = 1) 

--- a/ShinyForestry/backend/plumber_apis.R
+++ b/ShinyForestry/backend/plumber_apis.R
@@ -493,8 +493,8 @@ function(res, which_cluster = 1) {
   
   if(!which_cluster %in% c(1,2,3,4)) {
     res$status <- 403
-    notif("thethe choice must be between 1 and 4", log_level = "error")
-    return("the choice must be between 1 and 4")
+    notif("which_cluster must be between 1 and 4", log_level = "error")
+    return("which_cluster must be between 1 and 4")
   }
   
   if (is.null(target_compatible_strategies$cluster)) {

--- a/ShinyForestry/bayesian-optimization-functions.R
+++ b/ShinyForestry/bayesian-optimization-functions.R
@@ -155,7 +155,7 @@ generate_legal_unique_samples <- function(n,
         temp <- tail(temp, rows)
         temp_high_dimension <- RRembo_project_low_dimension_to_high_dimension_basic(DoE_low_dimension = temp, A = A)
         
-        # Turn values between 0 and 1 to legal area values by rounding then multiplying
+        # Turn values between 0 and 1 to legal Area values by rounding then multiplying
         temp_high_dimension_categorical <- transform_DoE_high_dimension_continuous_to_strategy_rowwise_matrix(DoE_high_dimension_rowwise_matrix = temp_high_dimension,
                                                                                                               RREMBO_HYPER_PARAMETERS_arg = RREMBO_HYPER_PARAMETERS,
                                                                                                               FullTable_arg = FullTable,
@@ -200,7 +200,7 @@ generate_legal_unique_samples <- function(n,
       # If we are using maximinLHS, valid_samples is an empty data.frame/tibble
       # if (isFALSE(use_dplyr)) {
       colnames_samples <- colnames(samples)
-      area_cols <- grep("area", colnames_samples)
+      area_cols <- grep("Area", colnames_samples)
       samples_area_numeric <- samples[, area_cols, drop = FALSE]
       # apply works naturally on columns, so either pass 2 or transpose after
       samples_area_numeric <- apply(samples_area_numeric, 2, as.numeric)
@@ -500,7 +500,7 @@ transform_DoE_high_dimension_continuous_to_strategy_rowwise_matrix <- function(
   # Possible values for Area, and Tree Specie (Years later)
   area_possible_non_zero_values <- FullTable %>%
     sf::st_drop_geometry() %>%
-    dplyr::select(area) %>%
+    dplyr::select(Area) %>%
     unlist(use.names = FALSE)
   # Prevent potential miscalculations
   area_possible_non_zero_values[year_of_max_no_planting_threshold_vector == MAXYEAR] <- 0
@@ -752,7 +752,7 @@ get_outcomes_from_strategy <- function(parameter_vector,
   
   # Remove invalid rows 3 ms ----
   FullTable_long <- FullTable_long[
-    # Filter rows where area is non-zero and conditions on tree species match
+    # Filter rows where Area is non-zero and conditions on tree species match
     strategy_area != 0 &
       treespecie == strategy_treespecie,
   ]
@@ -998,7 +998,7 @@ generate_samples_RRembo <- function(d, lower, upper, budget = 100,
   DoE_low_dimension <- map(DoE_low_dimension, A)
   notif(paste(msg, "done"), log_level = "debug", max_limit_log_level = max_limit_log_level)
   
-  # Turn values between 0 and 1 to legal area values by rounding then multiplying
+  # Turn values between 0 and 1 to legal Area values by rounding then multiplying
   msg <- "RREMBO generating data. Generate high dimension data part 2 (map to categorical values) ..."
   notif(msg, log_level = "debug", max_limit_log_level = max_limit_log_level)
   values <- continuous_to_categorical(values = DoE_high_dimension,
@@ -1586,7 +1586,7 @@ batch_selection <- function(acquisition_values, batch_size = 1, max_limit_log_le
   return(order(acquisition_values, decreasing = TRUE)[1:batch_size])
 }
 
-objective_function <- function(inputs, # c(area, year_planting, tree_specie)
+objective_function <- function(inputs, # c(Area, year_planting, tree_specie)
                                area_sum_threshold, # number
                                year_of_max_no_planting_threshold_vector, # vector
                                FullTable_arg,
@@ -2487,10 +2487,10 @@ bayesian_optimization <- function(
       "# strategies searched" = n + n * BAYESIAN_OPTIMIZATION_ITERATIONS,
       "# strategies evaluated" = (2 * BAYESIAN_OPTIMIZATION_ITERATIONS) * BAYESIAN_OPTIMIZATION_BATCH_SIZE + 10 * 6,
       "# locations" = number_of_locations,
-      "Σarea summary" = paste0(round(sum_area, 2), collapse = "; "),
-      "area max" = area_sum_threshold,
-      "Σcarbon summary" = paste0(round(sum_carbon, 2), collapse = "; "),
-      "carbon min" = outcomes_to_maximize_sum_threshold_vector["Carbon"],
+      "ΣArea summary" = paste0(round(sum_area, 2), collapse = "; "),
+      "Area max" = area_sum_threshold,
+      "ΣCarbon summary" = paste0(round(sum_carbon, 2), collapse = "; "),
+      "Carbon min" = outcomes_to_maximize_sum_threshold_vector["Carbon"],
       # "sum area_invalidness" = sum(diff_area_possible, na.rm = TRUE),
       # "obj_value" = paste0(obj_outputs[legal_output_indices], collapse = "; "),
       # "exploration coefficient" = EXPLORATION_COEFFICIENT,
@@ -2511,7 +2511,7 @@ bayesian_optimization <- function(
     # print(notif_msg)
     notif(notif_msg, rbind  = TRUE, max_limit_log_level = max_limit_log_level)
     
-    # Sum area / Sum carbon
+    # Sum Area / Sum Carbon
     if (isTRUE(PLOT)) {
       
       carbon_vectors <- matrix(carbon_possible_non_zero_values, ncol = RREMBO_HYPER_PARAMETERS$D, nrow = nrow(obj_inputs), byrow = TRUE)
@@ -2552,10 +2552,10 @@ bayesian_optimization <- function(
                  xmin = outcomes_to_maximize_sum_threshold_vector[1], xmax = Inf, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Carbon sums, tab 2",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Carbon sums",
              y = "Obj value")
-      ggsave("tab2-carbon-obj.png")
+      ggsave("tab2-Carbon-obj.png")
       # with animation
       all_rows <- data.frame(sumcarbon = rowSums(obj_inputs), obj = obj_outputs) |>
         unique()
@@ -2580,7 +2580,7 @@ bayesian_optimization <- function(
                  xmin = outcomes_to_maximize_sum_threshold_vector[1], xmax = Inf, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Area sums, tab 2, {closest_state}",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Area sums",
              y = "Obj value")
       gganimate::animate(a,
@@ -2589,7 +2589,7 @@ bayesian_optimization <- function(
                          width = 1920,
                          height = 1080,
                          renderer = gifski_renderer()) |>
-        gganimate::anim_save(filename = "tab2-carbon-obj.gif")
+        gganimate::anim_save(filename = "tab2-Carbon-obj.gif")
       
       
       
@@ -2603,10 +2603,10 @@ bayesian_optimization <- function(
                  xmin = -Inf, xmax = area_sum_threshold, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Area sums, tab 2",
-             subtitle = "Green is the set of target-compatible area sums",
+             subtitle = "Green is the set of target-compatible Area sums",
              x = "Area sums",
              y = "Obj value")
-      ggsave("tab2-area-obj.png")
+      ggsave("tab2-Area-obj.png")
       # with animation
       all_rows <- data.frame(sumarea = rowSums(obj_inputs), obj = obj_outputs) |>
         unique()
@@ -2631,7 +2631,7 @@ bayesian_optimization <- function(
                  xmin = -Inf, xmax = area_sum_threshold, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Area sums, tab 2, {closest_state}",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Area sums",
              y = "Obj value")
       gganimate::animate(a,
@@ -2640,7 +2640,7 @@ bayesian_optimization <- function(
                          width = 1920,
                          height = 1080,
                          renderer = gifski_renderer()) |>
-        gganimate::anim_save(filename = "tab2-area-obj.gif")
+        gganimate::anim_save(filename = "tab2-Area-obj.gif")
       
       # Map
       # Target-compatible obj_inputs
@@ -2725,10 +2725,10 @@ bayesian_optimization <- function(
                  xmin = outcomes_to_maximize_sum_threshold_vector[1], xmax = Inf, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Carbon sums, tab 1",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Carbon sums",
              y = "Obj value")
-      ggsave("tab1-carbon-obj.png")
+      ggsave("tab1-Carbon-obj.png")
       # with animation
       all_rows <- data.frame(sumcarbon = rowSums(carbon_vectors), obj = obj_outputs) |>
         unique()
@@ -2753,7 +2753,7 @@ bayesian_optimization <- function(
                  xmin = outcomes_to_maximize_sum_threshold_vector[1], xmax = Inf, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Carbon sums, tab 1, {closest_state}",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Carbon sums",
              y = "Obj value")
       gganimate::animate(a,
@@ -2762,7 +2762,7 @@ bayesian_optimization <- function(
                          width = 1920,
                          height = 1080,
                          renderer = gifski_renderer()) |>
-        gganimate::anim_save(filename = "tab1-carbon-obj.gif")
+        gganimate::anim_save(filename = "tab1-Carbon-obj.gif")
       
       
       
@@ -2777,10 +2777,10 @@ bayesian_optimization <- function(
                  xmin = -Inf, xmax = area_sum_threshold, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Area sums, tab 1",
-             subtitle = "Green is the set of target-compatible area sums",
+             subtitle = "Green is the set of target-compatible Area sums",
              x = "Area sums",
              y = "Obj value")
-      ggsave("tab1-area-obj.png")
+      ggsave("tab1-Area-obj.png")
       # with animation
       all_rows <- data.frame(sumarea = rowSums(obj_inputs), obj = obj_outputs) |>
         unique()
@@ -2805,7 +2805,7 @@ bayesian_optimization <- function(
                  xmin = -Inf, xmax = area_sum_threshold, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Area sums, tab 1, {closest_state}",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Area sums",
              y = "Obj value")
       gganimate::animate(a,
@@ -2814,20 +2814,20 @@ bayesian_optimization <- function(
                          width = 1920,
                          height = 1080,
                          renderer = gifski_renderer()) |>
-        gganimate::anim_save(filename = "tab1-area-obj.gif")
+        gganimate::anim_save(filename = "tab1-Area-obj.gif")
     }
     
     notif_msg <- rbind(
       "# strategies searched" = n + n * BAYESIAN_OPTIMIZATION_ITERATIONS,
       "# strategies evaluated" = (2 * BAYESIAN_OPTIMIZATION_ITERATIONS) * BAYESIAN_OPTIMIZATION_BATCH_SIZE + 10 * 6,
       "# locations" = number_of_locations,
-      "Σarea" = outcome$sum_area,
-      "area max" = area_sum_threshold,
-      "Σcarbon" = outcome$sum_carbon,
-      "carbon min" = outcomes_to_maximize_sum_threshold_vector["Carbon"],
+      "ΣArea" = outcome$sum_area,
+      "Area max" = area_sum_threshold,
+      "ΣCarbon" = outcome$sum_carbon,
+      "Carbon min" = outcomes_to_maximize_sum_threshold_vector["Carbon"],
       # "sum area_invalidness" = sum(diff_area_possible, na.rm = TRUE),
       "obj_value" = min(obj_outputs),
-      "preference weight area" = preference_weight_area,
+      "preference weight Area" = preference_weight_area,
       "preference weight outcomes to maximize" = toString(preference_weights_maximize),
       "# initial design points" = n,
       "smart REMBO" = RREMBO_SMART,

--- a/ShinyForestry/functions.R
+++ b/ShinyForestry/functions.R
@@ -1238,7 +1238,7 @@ observe_event_function_YearType <- function(choose = 1, # 1 for input$choose1, 2
 #  # SelectedSimMatBinary: convert SelectedSimMat without year of planting (binary)
 #  # SelectedSimMatYearOrSavedVec: matrix where the column where SavedVec=1 is replaced by 0 (planting at year 0)
 #  # SVMMAT: Matrix composed on SavedVec on every line (to do an OR later).
-#  # For the moment, the area does not change with year of planting.
+#  # For the moment, the Area does not change with year of planting.
 #  if (length(SavedVecYearLoc) == 1) {
 #    SelectedSimMat <- as.matrix(simul636YearLoc[, 1:length(SavedVecYearLoc)])
 #    SelectedSimMatBinary<- 1*(as.matrix(simul636YearLoc[, 1:length(SavedVecYearLoc)])!=(MAXYEAR+1))
@@ -1439,7 +1439,7 @@ outputmap_calculateMatsYearType <- function(input,
   # SelectedSimMatBinary: convert SelectedSimMat without year of planting (binary)
   # SelectedSimMatYearOrSavedVec: matrix where the column where SavedVec=1 is replaced by 0 (planting at year 0)
   # SVMMAT: Matrix composed on SavedVec on every line (to do an OR later).
-  # For the moment, the area does not change with year of planting.
+  # For the moment, the Area does not change with year of planting.
   if (length(SavedVecYearTypeLoc) == 1) {
     SelectedSimMat <- as.matrix(simul636YearTypeLoc$YEAR[, 1:length(SavedVecYearTypeLoc)])
     SelectedSimMatBinary<- 1*(as.matrix(simul636YearTypeLoc$YEAR[, 1:length(SavedVecYearTypeLoc)])!=(-1))
@@ -2451,16 +2451,16 @@ get_richness_from_fulltable <- function(strategy_vector, FullTable_arg = FullTab
   treespecie_vector <- strategy_vector[indices]
   
   small_fulltable_dt <- FullTable %>%
-    mutate(area = area_vector,
+    mutate(Area = area_vector,
            year = year_vector,
            treespecie = treespecie_vector) %>%
-    dplyr::select(area, year, treespecie, starts_with("Richness")) %>%
+    dplyr::select(Area, year, treespecie, starts_with("Richness")) %>%
     mutate(parcel_id = 1:nrow(FullTable)) |>
     setDT()
   
   # Melt the data table to convert from wide to long format
   melted_dt <- data.table::melt(small_fulltable_dt, 
-                                id.vars = c("area", "year", "treespecie", "parcel_id"), 
+                                id.vars = c("Area", "year", "treespecie", "parcel_id"), 
                                 measure.vars = grep("Richness", colnames(small_fulltable_dt), value = TRUE),
                                 variable.name = "column_name", 
                                 value.name = "richness")
@@ -2474,11 +2474,11 @@ get_richness_from_fulltable <- function(strategy_vector, FullTable_arg = FullTab
   
   # Remove rows where the column_name's tree specie is not the strategy treespecie
   # and where the planting year is not the strategy plantingyear
-  # and where we don't plant (area is 0)
+  # and where we don't plant (Area is 0)
   # and where plantingyear is 25
   melted_dt <- melted_dt[colname_treespecie == treespecie &
                            colname_plantingyear == year &
-                           area != 0 &
+                           Area != 0 &
                            colname_plantingyear != MAXYEAR + 1, ]
   
   # Sum richness by group
@@ -2583,7 +2583,7 @@ convert_bio_to_polygons_from_elicitor_and_merge_into_FullTable <- function(Elici
   intersection <- st_intersection(polygons_bio, polygons_jules)
   notif(paste(msg, "done"), max_limit_log_level = max_limit_log_level)
   
-  # Look at the area difference rowwise for mutate
+  # Look at the Area difference rowwise for mutate
   compute_difference_area <- function(geom1, geom2) {
     diff_geom <- st_difference(geom1, geom2)
     if (!is_empty(diff_geom)) {
@@ -2594,7 +2594,7 @@ convert_bio_to_polygons_from_elicitor_and_merge_into_FullTable <- function(Elici
   }
   
   # Calculate the proportion of areas (intersection / bio)
-  msg <- "Calculate the biodiversity values in shapefile cells, weighted by area ..."
+  msg <- "Calculate the biodiversity values in shapefile cells, weighted by Area ..."
   notif(msg, max_limit_log_level = max_limit_log_level)
   
   # We use progression bars inside and outside of functions, and this causes problems, local({}) solves them
@@ -2655,7 +2655,7 @@ convert_bio_to_polygons_from_elicitor_and_merge_into_FullTable <- function(Elici
       
       # Group by polygon_id_jules and average over parcels
       {
-        msg <- "Average biodiversities across (carbon, new) parcels"
+        msg <- "Average biodiversities across (Carbon, new) parcels"
         pb(message = msg)
         notif(paste("5/7", msg), max_limit_log_level = max_limit_log_level)
         invisible(.)
@@ -2684,7 +2684,7 @@ convert_bio_to_polygons_from_elicitor_and_merge_into_FullTable <- function(Elici
       ) %>% 
       
       {
-        msg <- "Compute area differences"
+        msg <- "Compute Area differences"
         pb(message = msg)
         notif(paste("6/7", msg), max_limit_log_level = max_limit_log_level)
         invisible(.)
@@ -3221,7 +3221,7 @@ generate_parcel_data <- function(FullTable) {
   empty_parcel_data <- generate_empty_parcel_data(FullTable)
   
   n <- nrow(empty_parcel_data)
-  parcel_areas <- FullTable$area
+  parcel_areas <- FullTable$Area
   planting_years <- sample(2025:2049, n, replace = TRUE)
   planting_types <- sample(c("Deciduous", "Conifer", NA), n, replace = TRUE)
   planting_years[is.na(planting_types)] <- NA

--- a/ShinyForestry/modules/map_page.R
+++ b/ShinyForestry/modules/map_page.R
@@ -179,7 +179,7 @@ map_page_server <- function(id, state) {
       # Convert total_area to km²
       plot_data$total_area <- set_units(plot_data$total_area, "km^2")
       
-      # Compute cumulative area for each planting type
+      # Compute cumulative Area for each planting type
       cumulative_data <- plot_data %>%
         arrange(planting_types, planting_year) %>%
         group_by(planting_types) %>%
@@ -192,7 +192,7 @@ map_page_server <- function(id, state) {
     
     observe({
       if (state$map_tab$initialized) {
-        print("render area plot")
+        print("render Area plot")
         # Render time-series plot for both Conifer and Deciduous
         output[[ns("areaPlot")]] <- renderPlotly({
           data <- processed_data()  # Get precomputed data
@@ -307,13 +307,13 @@ map_page_server <- function(id, state) {
           dplyr::filter(!is.na(planting_year)) %>%
           # dplyr::mutate( # I don't think we need to do this as it's fine as it is.
           #   geometry = st_make_valid(geometry),  # Ensure valid geometries
-          #   parcel_area = st_area(geometry)      # Calculate area of each polygon
+          #   parcel_area = st_area(geometry)      # Calculate Area of each polygon
           # ) %>%
           dplyr::group_by(planting_year, planting_types) %>%
           dplyr::summarise(total_area = sum(parcel_area, na.rm = TRUE), .groups = 'drop') %>%  # Avoid warning with `.groups`
           dplyr::arrange(planting_year)  # Ensures chronological order
         
-        # Save the area data for later use in plots
+        # Save the Area data for later use in plots
         output_data(area_data)
         
         # Render the leaflet map with the updated data
@@ -438,16 +438,16 @@ map_page_server <- function(id, state) {
         # state$map_tab$slider
         # │
         # ├── names  (List of slider names)
-        # │   ├── "carbon"
+        # │   ├── "Carbon"
         # │   ├── "species"
         # │   ├── "species_goat_moth"
         # │   ├── "species_stag_beetle"
         # │   ├── "species_lichens"
-        # │   ├── "area"
-        # │   ├── "recreation"
+        # │   ├── "Area"
+        # │   ├── "Recreation"
         # │
         # └── values  (Named list of slider parameters)
-        #     ├── carbon
+        #     ├── Carbon
         #     │   ├── min: 500
         #     │   ├── max: 1000
         #     │   └── default: 800
@@ -469,21 +469,21 @@ map_page_server <- function(id, state) {
         #
         # slider_info <- list(
         #   min_max_default = data.table(
-        #     carbon = c(0, 10, 4),
+        #     Carbon = c(0, 10, 4),
         #     species = c(0, 10, 4),
         #     species_goat_moth = c(0, 10, 4),
         #     species_stag_beetle = c(0, 10, 4),
         #     species_lichens = c(0, 10, 4),
-        #     area = c(0, 10, 4),
-        #     recreation = c(0, 10, 4)),
+        #     Area = c(0, 10, 4),
+        #     Recreation = c(0, 10, 4)),
         #   units = data.table(
-        #     carbon = "tCO₂",
+        #     Carbon = "tCO₂",
         #     species = "%",
         #     species_goat_moth = "%",
         #     species_stag_beetle = "%",
         #     species_lichens = "%",
-        #     area = "km²",
-        #     recreation = "10³Kcal")
+        #     Area = "km²",
+        #     Recreation = "10³Kcal")
         # )
         
         # Convert slider_info into the desired format
@@ -937,13 +937,13 @@ map_page_server <- function(id, state) {
     #     saved_data = new_data(),
     #     clicked_polygons = clicked_polygons(),
     #     
-    #     carbon = input$carbon,
+    #     Carbon = input$Carbon,
     #     species = input$species,
     #     species_goat_moth = input$species_goat_moth,
     #     species_stag_beetle = input$species_stag_beetle,
     #     species_lichens = input$species_lichens,
-    #     area = input$area,
-    #     recreation = input$recreation,
+    #     Area = input$Area,
+    #     Recreation = input$Recreation,
     #     
     #     year = input$year,
     #     
@@ -981,13 +981,13 @@ map_page_server <- function(id, state) {
     #       new_data(strategy$saved_data)
     #       clicked_polygons(strategy$clicked_polygons)
     #       
-    #       updateSliderInput(session, "carbon", value = strategy$carbon)
+    #       updateSliderInput(session, "Carbon", value = strategy$Carbon)
     #       updateSliderInput(session, "species", value = strategy$species)
     #       updateSliderInput(session, "species_goat_moth", value = strategy$species_goat_moth)
     #       updateSliderInput(session, "species_stag_beetle", value = strategy$species_stag_beetle)
     #       updateSliderInput(session, "species_lichens", value = strategy$species_lichens)
-    #       updateSliderInput(session, "area", value = strategy$area)
-    #       updateSliderInput(session, "recreation", value = strategy$recreation)
+    #       updateSliderInput(session, "Area", value = strategy$Area)
+    #       updateSliderInput(session, "Recreation", value = strategy$Recreation)
     #       
     #       updateCheckboxInput(session, "carbon_checkbox", value = strategy$carbon_checkbox)
     #       updateCheckboxInput(session, "species_checkbox", value = strategy$species_checkbox)

--- a/ShinyForestry/preferTrees.R
+++ b/ShinyForestry/preferTrees.R
@@ -65,7 +65,7 @@ Normal <- function(mu = 0.0, sigma = 1.0){
   return(list(f=f, mean=mu, sd=sigma, s_fun=sample_fun))
 }
 
-#' A function to determine lower bounds on the posterior for use by parallel tempering mcmc only. Function is designed to be conservative with the broad aim to scale an output to [0,1] and for the fitted parameters to roughly be interpretable as weights ([-1,1]) where negative weight indicates a preference for less of a thing (like area)
+#' A function to determine lower bounds on the posterior for use by parallel tempering mcmc only. Function is designed to be conservative with the broad aim to scale an output to [0,1] and for the fitted parameters to roughly be interpretable as weights ([-1,1]) where negative weight indicates a preference for less of a thing (like Area)
 #' @param p an object of class PrefElciitClass
 #' @param index which input (as in which data column) do you want a bound for?
 lbfun <- function(p, index){

--- a/ShinyForestry/tabx.R
+++ b/ShinyForestry/tabx.R
@@ -371,13 +371,13 @@ server <- function(input, output, session) {
   
   # Track the initial slider values when the submit button is clicked
   initial_values <- reactiveVal(list(
-    carbon = NULL,
+    Carbon = NULL,
     species = NULL,
     species_goat_moth = NULL,
     species_stag_beetle = NULL,
     species_lichens = NULL,
-    area = NULL,
-    recreation = NULL
+    Area = NULL,
+    Recreation = NULL
     # year = NULL
     # num_clicked_polygons = 0 # not sure if this is the best way, what about if polygons are blocked online... I guess that's fine.
   ))
@@ -434,7 +434,7 @@ server <- function(input, output, session) {
     # Convert total_area to km²
     plot_data$total_area <- set_units(plot_data$total_area, "km^2")
     
-    # Compute cumulative area for each planting type
+    # Compute cumulative Area for each planting type
     cumulative_data <- plot_data %>%
       arrange(planting_type, planting_year) %>%
       group_by(planting_type) %>%
@@ -477,8 +477,8 @@ server <- function(input, output, session) {
         ),
         showlegend = TRUE,
         # Set transparent background
-        paper_bgcolor = "rgba(255, 255, 255, 0)",  # Transparent background for the entire plot area
-        plot_bgcolor = "rgba(255, 255, 255, 0)"   # Transparent background for the plot area itself
+        paper_bgcolor = "rgba(255, 255, 255, 0)",  # Transparent background for the entire plot Area
+        plot_bgcolor = "rgba(255, 255, 255, 0)"   # Transparent background for the plot Area itself
       )
     
     fig
@@ -606,13 +606,13 @@ server <- function(input, output, session) {
         dplyr::filter(!is.na(planting_year)) %>%
         # dplyr::mutate( # I don't think we need to do this as it's fine as it is.
         #   geometry = st_make_valid(geometry),  # Ensure valid geometries
-        #   parcel_area = st_area(geometry)      # Calculate area of each polygon
+        #   parcel_area = st_area(geometry)      # Calculate Area of each polygon
         # ) %>%
         dplyr::group_by(planting_year, planting_type) %>%
         dplyr::summarise(total_area = sum(parcel_area, na.rm = TRUE), .groups = 'drop') %>%  # Avoid warning with `.groups`
         dplyr::arrange(planting_year)  # Ensures chronological order
       
-      # Save the area data for later use in plots
+      # Save the Area data for later use in plots
       output_data(area_data)
       
       # Render the leaflet map with the updated data
@@ -713,25 +713,25 @@ server <- function(input, output, session) {
   observe({
     default_values <- fetch_slider_values()  # Fetch once at startup
     default_payload <<- list(
-      carbon = default_values$carbon$default,
+      Carbon = default_values$Carbon$default,
       species = default_values$species$default,
       species_goat_moth = default_values$species_goat_moth$default,
       species_stag_beetle = default_values$species_stag_beetle$default,
       species_lichens = default_values$species_lichens$default,
-      area = default_values$area$default,
-      recreation = default_values$recreation$default,
+      Area = default_values$Area$default,
+      Recreation = default_values$Recreation$default,
       blocked_parcels = list()
     )
     
     initial_values(
       list(
-        carbon = default_values$carbon$default,
+        Carbon = default_values$Carbon$default,
         species = default_values$species$default,
         species_goat_moth = default_values$species_goat_moth$default,
         species_stag_beetle = default_values$species_stag_beetle$default,
         species_lichens = default_values$species_lichens$default,
-        area = default_values$area$default,
-        recreation = default_values$recreation$default
+        Area = default_values$Area$default,
+        Recreation = default_values$Recreation$default
       )
     )
     
@@ -741,10 +741,10 @@ server <- function(input, output, session) {
       tagList(
         fluidRow(
           column(CHECKBOX_COL, checkboxInput("carbon_checkbox", NULL, value = TRUE)),
-          column(SLIDER_COL, sliderInput("carbon", HTML(paste0("Tree Carbon Stored (tonnes of CO<sub>2</sub>):")),
-                                         min = default_values$carbon$min, 
-                                         max = default_values$carbon$max, 
-                                         value = default_values$carbon$default
+          column(SLIDER_COL, sliderInput("Carbon", HTML(paste0("Tree Carbon Stored (tonnes of CO<sub>2</sub>):")),
+                                         min = default_values$Carbon$min, 
+                                         max = default_values$Carbon$max, 
+                                         value = default_values$Carbon$default
           ))
         ),
         fluidRow(
@@ -781,18 +781,18 @@ server <- function(input, output, session) {
         ),
         fluidRow(
           column(CHECKBOX_COL, checkboxInput("area_checkbox", NULL, value = TRUE)),
-          column(SLIDER_COL, sliderInput("area", HTML(paste0("Area Planted (km<sup>2</sup>):")),
-                                         min = default_values$area$min, 
-                                         max = default_values$area$max, 
-                                         value = default_values$area$default
+          column(SLIDER_COL, sliderInput("Area", HTML(paste0("Area Planted (km<sup>2</sup>):")),
+                                         min = default_values$Area$min, 
+                                         max = default_values$Area$max, 
+                                         value = default_values$Area$default
           ))
         ),
         fluidRow(
           column(CHECKBOX_COL, checkboxInput("recreation_checkbox", NULL, value = TRUE)),
-          column(SLIDER_COL, sliderInput("recreation", "Recreation (visits per month):", 
-                                         min = default_values$recreation$min, 
-                                         max = default_values$recreation$max, 
-                                         value = default_values$recreation$default
+          column(SLIDER_COL, sliderInput("Recreation", "Recreation (Visits per month):", 
+                                         min = default_values$Recreation$min, 
+                                         max = default_values$Recreation$max, 
+                                         value = default_values$Recreation$default
           ))
         )
       )
@@ -827,13 +827,13 @@ server <- function(input, output, session) {
     shinyjs::disable("save")
     shinyjs::disable("reset")
     shinyjs::disable("submit")
-    shinyjs::disable("carbon")
+    shinyjs::disable("Carbon")
     shinyjs::disable("species")
     shinyjs::disable("species_goat_moth")
     shinyjs::disable("species_stag_beetle")
     shinyjs::disable("species_lichens")
-    shinyjs::disable("area")
-    shinyjs::disable("recreation")    
+    shinyjs::disable("Area")
+    shinyjs::disable("Recreation")    
     shinyjs::disable("carbon_checkbox")
     shinyjs::disable("species_checkbox")
     shinyjs::disable("species_goat_moth_checkbox")
@@ -844,13 +844,13 @@ server <- function(input, output, session) {
     
     # Save the initial values when the submit button is clicked
     initial_values(list(
-      carbon = input$carbon,
+      Carbon = input$Carbon,
       species = input$species,
       species_goat_moth = input$species_goat_moth,
       species_stag_beetle = input$species_stag_beetle,
       species_lichens = input$species_lichens,
-      area = input$area,
-      recreation = input$recreation
+      Area = input$Area,
+      Recreation = input$Recreation
       # year = input$year
       # num_clicked_polygons = 0
     ))
@@ -861,13 +861,13 @@ server <- function(input, output, session) {
     
     # Create the payload
     payload <- list(
-      carbon = as.numeric(input$carbon),
+      Carbon = as.numeric(input$Carbon),
       species = as.numeric(input$species),
       species_goat_moth = as.numeric(input$species_goat_moth),
       species_stag_beetle = as.numeric(input$species_stag_beetle),
       species_lichens = as.numeric(input$species_lichens),
-      area = as.numeric(input$area),
-      recreation = as.numeric(input$recreation),
+      Area = as.numeric(input$Area),
+      Recreation = as.numeric(input$Recreation),
       blocked_parcels = if (nrow(blocked_parcels_filtered) > 0) {
         # Create a list of blocked parcels
         lapply(1:nrow(blocked_parcels_filtered), function(i) {
@@ -931,13 +931,13 @@ server <- function(input, output, session) {
     #   fig
     # })
     
-    shinyjs::enable("carbon")
+    shinyjs::enable("Carbon")
     shinyjs::enable("species")
     shinyjs::enable("species_goat_moth")
     shinyjs::enable("species_stag_beetle")
     shinyjs::enable("species_lichens")
-    shinyjs::enable("area")
-    shinyjs::enable("recreation")
+    shinyjs::enable("Area")
+    shinyjs::enable("Recreation")
     shinyjs::enable("carbon_checkbox")
     shinyjs::enable("species_checkbox")
     shinyjs::enable("species_goat_moth_checkbox")
@@ -999,13 +999,13 @@ server <- function(input, output, session) {
   observe({
     # Get the current slider values
     current_values <- list(
-      carbon = input$carbon,
+      Carbon = input$Carbon,
       species = input$species,
       species_goat_moth = input$species_goat_moth,
       species_stag_beetle = input$species_stag_beetle,
       species_lichens = input$species_lichens,
-      area = input$area,
-      recreation = input$recreation
+      Area = input$Area,
+      Recreation = input$Recreation
       # year = input$year
       # num_clicked_polygons = nrow(clicked_polygons()[clicked_polygons()$blocked_until_year != 0, ]) # not sure if this is how to do it 
     )
@@ -1197,13 +1197,13 @@ server <- function(input, output, session) {
   
   # Enable/Disable sliders
   observe({
-    toggleState("carbon", input$carbon_checkbox)
+    toggleState("Carbon", input$carbon_checkbox)
     toggleState("species", input$species_checkbox)
     toggleState("species_goat_moth", input$species_goat_moth_checkbox)
     toggleState("species_stag_beetle", input$species_stag_beetle_checkbox)
     toggleState("species_lichens", input$species_lichens_checkbox)
-    toggleState("area", input$area_checkbox)
-    toggleState("recreation", input$recreation_checkbox)
+    toggleState("Area", input$area_checkbox)
+    toggleState("Recreation", input$recreation_checkbox)
   })
   
   # Render the "Saved Strategies" accordion dynamically
@@ -1240,13 +1240,13 @@ server <- function(input, output, session) {
       saved_data = new_data(),
       clicked_polygons = clicked_polygons(),
       
-      carbon = input$carbon,
+      Carbon = input$Carbon,
       species = input$species,
       species_goat_moth = input$species_goat_moth,
       species_stag_beetle = input$species_stag_beetle,
       species_lichens = input$species_lichens,
-      area = input$area,
-      recreation = input$recreation,
+      Area = input$Area,
+      Recreation = input$Recreation,
       
       year = input$year,  # Save the year as well
       
@@ -1279,13 +1279,13 @@ server <- function(input, output, session) {
         new_data(strategy$saved_data)
         clicked_polygons(strategy$clicked_polygons)
         
-        updateSliderInput(session, "carbon", value = strategy$carbon)
+        updateSliderInput(session, "Carbon", value = strategy$Carbon)
         updateSliderInput(session, "species", value = strategy$species)
         updateSliderInput(session, "species_goat_moth", value = strategy$species_goat_moth)
         updateSliderInput(session, "species_stag_beetle", value = strategy$species_stag_beetle)
         updateSliderInput(session, "species_lichens", value = strategy$species_lichens)
-        updateSliderInput(session, "area", value = strategy$area)
-        updateSliderInput(session, "recreation", value = strategy$recreation)
+        updateSliderInput(session, "Area", value = strategy$Area)
+        updateSliderInput(session, "Recreation", value = strategy$Recreation)
         
         updateCheckboxInput(session, "carbon_checkbox", value = strategy$carbon_checkbox)
         updateCheckboxInput(session, "species_checkbox", value = strategy$species_checkbox)
@@ -1308,13 +1308,13 @@ server <- function(input, output, session) {
       setView(lat = LAT_DEFAULT, lng = LON_DEFAULT, zoom = ZOOM_DEFAULT)
     
     # Reset sliders to default values
-    updateSliderInput(session, "carbon", value = CARBON_DEFAULT)
+    updateSliderInput(session, "Carbon", value = CARBON_DEFAULT)
     updateSliderInput(session, "species", value = SPECIES_DEFAULT)
     updateSliderInput(session, "species_goat_moth", value = SPECIES_GM_DEFAULT)
     updateSliderInput(session, "species_stag_beetle", value = SPECIES_SB_DEFAULT)
     updateSliderInput(session, "species_lichens", value = SPECIES_LICHENS_DEFAULT)
-    updateSliderInput(session, "area", value = AREA_DEFAULT)
-    updateSliderInput(session, "recreation", value = RECREATION_DEFAULT)
+    updateSliderInput(session, "Area", value = AREA_DEFAULT)
+    updateSliderInput(session, "Recreation", value = RECREATION_DEFAULT)
     updateSliderInput(session, "year", value = YEAR_DEFAULT)  # Reset year slider
     
     # Reset checkboxes to default values

--- a/ShinyForestry/utils/api_interface.R
+++ b/ShinyForestry/utils/api_interface.R
@@ -66,21 +66,21 @@ frontend_initialisation <- funtion() {
     ),
     # slider_info <- list(
     #   min_max_default = data.table(
-    #     carbon = c(0, 10, 4),
+    #     Carbon = c(0, 10, 4),
     #     species = c(0, 10, 4),
     #     species_goat_moth = c(0, 10, 4),
     #     species_stag_beetle = c(0, 10, 4),
     #     species_lichens = c(0, 10, 4),
-    #     area = c(0, 10, 4),
-    #     recreation = c(0, 10, 4)),
+    #     Area = c(0, 10, 4),
+    #     Recreation = c(0, 10, 4)),
     #   units = data.table(
-    #     carbon = "tCO₂",
+    #     Carbon = "tCO₂",
     #     species = "%",
     #     species_goat_moth = "%",
     #     species_stag_beetle = "%",
     #     species_lichens = "%",
-    #     area = "km²",
-    #     recreation = "10³Kcal")
+    #     Area = "km²",
+    #     Recreation = "10³Kcal")
     # )
   )
   return(targets)

--- a/ShinyForestry/utils/api_interface.R
+++ b/ShinyForestry/utils/api_interface.R
@@ -94,6 +94,6 @@ convert_targets_to_english <- function(targets, name_conversion) {
   converted_targets <- ifelse(targets %in% names(lookup_table), lookup_table[targets], targets)
   return(converted_targets)
 }
-targets <- convert_targets_to_english(initialization$TARGETS, initialization$NAME_CONVERSION)
-
-}
+# targets <- convert_targets_to_english(initialization$TARGETS, initialization$NAME_CONVERSION)
+# 
+# }

--- a/backend/DannyFunctions.R
+++ b/backend/DannyFunctions.R
@@ -120,7 +120,7 @@ transform_DoE_high_dimension_continuous_to_strategy_rowwise_matrix_dw <- functio
   # Area
   DoE_high_dimension_rowwise_matrix_area_normalized <- DoE_high_dimension_rowwise_matrix[, indices, drop = FALSE]
   
-  # Convert Area to categorical values, uses old continuous_to_multi_categorical as unique area vals on each parcel. Could be faster
+  # Convert Area to categorical values, uses old continuous_to_multi_categorical as unique Area vals on each parcel. Could be faster
   DoE_high_dimension_categorical_area <- continuous_to_multi_categorical_new(
     values_matrix =  DoE_high_dimension_rowwise_matrix_area_normalized,
     legal_values_ordered = area_possible_values_dataframe
@@ -335,7 +335,7 @@ compute_legal_values <- function(year_of_planting_min_threshold_vector,
 precompute_static_values <- function(FullTable, MAXYEAR) {
   
   # Precompute Area values
-  area_possible_non_zero_values <- FullTable$area
+  area_possible_non_zero_values <- FullTable$Area
   area_possible_values_dataframe <- rbind(0, area_possible_non_zero_values)
   max_ncol <- ncol(area_possible_values_dataframe)
   # Precompute Tree Specie Values
@@ -374,7 +374,7 @@ convert_outcome_to_dt <- function(outcome) {
   dt <- data.table::data.table(row_id = 1)  # Create a row to initialize the data.table
   
   for (name in names(outcome)) {
-    clean_name <- gsub("^sum_", "", name)
+    clean_name <- str_to_title(gsub("^sum_", "", name))
     if (is.numeric(outcome[[name]]) && length(names(outcome[[name]])) < 1) {
       dt[[clean_name]] <- outcome[[name]]
     } else if (is.numeric(outcome[[name]]) && length(names(outcome[[name]])) >= 1) {
@@ -445,7 +445,7 @@ make_strategy_forfront_preftab <- function(index){
   for_frontend <- st_sf(
     parcel_id = parcel_ids,
     geometry = FullTable$geometry,
-    parcel_area = FullTable$area,
+    parcel_area = FullTable$Area,
     planting_year = ifelse(tyears<2050,tyears,NA),
     planting_types = ifelse(tyears<2050, tspecies, NA),
     blocked_until_year = blocked_until_year,
@@ -457,9 +457,9 @@ make_strategy_forfront_preftab <- function(index){
   # In the update() function, it is converted to a matrix, so we need the comma to select the entire row
   payload <- pref_elicitation_object$data[comparison_index + (index-1), ]
   names(payload)[which(names(payload)=="All")] <- "Biodiversity"
-  names(payload)[which(names(payload)=="visits")] <- "Food_Produced"
-  names(payload)[which(names(payload)=="area")] <- "Area"
-  names(payload)[which(names(payload)=="carbon")] <- "Carbon"
+  names(payload)[which(names(payload)=="Visits")] <- "Food_Produced"
+  names(payload)[which(names(payload)=="Area")] <- "Area"
+  names(payload)[which(names(payload)=="Carbon")] <- "Carbon"
   bio_names_latin <- names(payload)[ ! names(payload)%in% c("Carbon", "Area", "Food_Produced", "Biodiversity")]
   bio_names_latin
   for(species in bio_names_latin){
@@ -506,7 +506,7 @@ make_strategy_forfront_altapproach <- function(index){
   for_frontend <- st_sf(
     parcel_id = parcel_ids,
     geometry = FullTable$geometry,
-    parcel_area = FullTable$area,
+    parcel_area = FullTable$Area,
     planting_year = ifelse(tyears<2050,tyears,NA),
     planting_types = ifelse(tyears<2050, tspecies, NA),
     blocked_until_year = blocked_until_year,
@@ -517,9 +517,9 @@ make_strategy_forfront_altapproach <- function(index){
   
   payload <- random_strategy[,..TARGETS]
   names(payload)[which(names(payload)=="All")] <- "Biodiversity"
-  names(payload)[which(names(payload)=="visits")] <- "Food_Produced"
-  names(payload)[which(names(payload)=="area")] <- "Area"
-  names(payload)[which(names(payload)=="carbon")] <- "Carbon"
+  names(payload)[which(names(payload)=="Visits")] <- "Food_Produced"
+  names(payload)[which(names(payload)=="Area")] <- "Area"
+  names(payload)[which(names(payload)=="Carbon")] <- "Carbon"
   bio_names_latin <- names(payload)[ ! names(payload)%in% c("Carbon", "Area", "Food_Produced", "Biodiversity")]
   bio_names_latin
   for(species in bio_names_latin){

--- a/backend/bayesian-optimization-functions.R
+++ b/backend/bayesian-optimization-functions.R
@@ -155,7 +155,7 @@ generate_legal_unique_samples <- function(n,
         temp <- tail(temp, rows)
         temp_high_dimension <- RRembo_project_low_dimension_to_high_dimension_basic(DoE_low_dimension = temp, A = A)
         
-        # Turn values between 0 and 1 to legal area values by rounding then multiplying
+        # Turn values between 0 and 1 to legal Area values by rounding then multiplying
         temp_high_dimension_categorical <- transform_DoE_high_dimension_continuous_to_strategy_rowwise_matrix(DoE_high_dimension_rowwise_matrix = temp_high_dimension,
                                                                                                               RREMBO_HYPER_PARAMETERS_arg = RREMBO_HYPER_PARAMETERS,
                                                                                                               FullTable_arg = FullTable,
@@ -200,7 +200,7 @@ generate_legal_unique_samples <- function(n,
       # If we are using maximinLHS, valid_samples is an empty data.frame/tibble
       # if (isFALSE(use_dplyr)) {
       colnames_samples <- colnames(samples)
-      area_cols <- grep("area", colnames_samples)
+      area_cols <- grep("Area", colnames_samples)
       samples_area_numeric <- samples[, area_cols, drop = FALSE]
       # apply works naturally on columns, so either pass 2 or transpose after
       samples_area_numeric <- apply(samples_area_numeric, 2, as.numeric)
@@ -500,7 +500,7 @@ transform_DoE_high_dimension_continuous_to_strategy_rowwise_matrix <- function(
   # Possible values for Area, and Tree Specie (Years later)
   area_possible_non_zero_values <- FullTable %>%
     sf::st_drop_geometry() %>%
-    dplyr::select(area) %>%
+    dplyr::select(Area) %>%
     unlist(use.names = FALSE)
   # Prevent potential miscalculations
   area_possible_non_zero_values[year_of_max_no_planting_threshold_vector == MAXYEAR] <- 0
@@ -752,7 +752,7 @@ get_outcomes_from_strategy <- function(parameter_vector,
   
   # Remove invalid rows 3 ms ----
   FullTable_long <- FullTable_long[
-    # Filter rows where area is non-zero and conditions on tree species match
+    # Filter rows where Area is non-zero and conditions on tree species match
     strategy_area != 0 &
       treespecie == strategy_treespecie,
   ]
@@ -998,7 +998,7 @@ generate_samples_RRembo <- function(d, lower, upper, budget = 100,
   DoE_low_dimension <- map(DoE_low_dimension, A)
   notif(paste(msg, "done"), log_level = "debug", max_limit_log_level = max_limit_log_level)
   
-  # Turn values between 0 and 1 to legal area values by rounding then multiplying
+  # Turn values between 0 and 1 to legal Area values by rounding then multiplying
   msg <- "RREMBO generating data. Generate high dimension data part 2 (map to categorical values) ..."
   notif(msg, log_level = "debug", max_limit_log_level = max_limit_log_level)
   values <- continuous_to_categorical(values = DoE_high_dimension,
@@ -1586,7 +1586,7 @@ batch_selection <- function(acquisition_values, batch_size = 1, max_limit_log_le
   return(order(acquisition_values, decreasing = TRUE)[1:batch_size])
 }
 
-objective_function <- function(inputs, # c(area, year_planting, tree_specie)
+objective_function <- function(inputs, # c(Area, year_planting, tree_specie)
                                area_sum_threshold, # number
                                year_of_max_no_planting_threshold_vector, # vector
                                FullTable_arg,
@@ -2469,10 +2469,10 @@ bayesian_optimization <- function(
       "# strategies searched" = n + n * BAYESIAN_OPTIMIZATION_ITERATIONS,
       "# strategies evaluated" = (2 * BAYESIAN_OPTIMIZATION_ITERATIONS) * BAYESIAN_OPTIMIZATION_BATCH_SIZE + 10 * 6,
       "# locations" = number_of_locations,
-      "Σarea summary" = paste0(round(sum_area, 2), collapse = "; "),
-      "area max" = area_sum_threshold,
-      "Σcarbon summary" = paste0(round(sum_carbon, 2), collapse = "; "),
-      "carbon min" = outcomes_to_maximize_sum_threshold_vector["Carbon"],
+      "ΣArea summary" = paste0(round(sum_area, 2), collapse = "; "),
+      "Area max" = area_sum_threshold,
+      "ΣCarbon summary" = paste0(round(sum_carbon, 2), collapse = "; "),
+      "Carbon min" = outcomes_to_maximize_sum_threshold_vector["Carbon"],
       # "sum area_invalidness" = sum(diff_area_possible, na.rm = TRUE),
       # "obj_value" = paste0(obj_outputs[legal_output_indices], collapse = "; "),
       # "exploration coefficient" = EXPLORATION_COEFFICIENT,
@@ -2493,7 +2493,7 @@ bayesian_optimization <- function(
     # print(notif_msg)
     notif(notif_msg, rbind  = TRUE, max_limit_log_level = max_limit_log_level)
     
-    # Sum area / Sum carbon
+    # Sum Area / Sum Carbon
     if (isTRUE(PLOT)) {
       
       carbon_vectors <- matrix(carbon_possible_non_zero_values, ncol = RREMBO_HYPER_PARAMETERS$D, nrow = nrow(obj_inputs), byrow = TRUE)
@@ -2534,10 +2534,10 @@ bayesian_optimization <- function(
                  xmin = outcomes_to_maximize_sum_threshold_vector[1], xmax = Inf, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Carbon sums, tab 2",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Carbon sums",
              y = "Obj value")
-      ggsave("tab2-carbon-obj.png")
+      ggsave("tab2-Carbon-obj.png")
       # with animation
       all_rows <- data.frame(sumcarbon = rowSums(obj_inputs), obj = obj_outputs) |>
         unique()
@@ -2562,7 +2562,7 @@ bayesian_optimization <- function(
                  xmin = outcomes_to_maximize_sum_threshold_vector[1], xmax = Inf, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Area sums, tab 2, {closest_state}",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Area sums",
              y = "Obj value")
       gganimate::animate(a,
@@ -2571,7 +2571,7 @@ bayesian_optimization <- function(
                          width = 1920,
                          height = 1080,
                          renderer = gifski_renderer()) |>
-        gganimate::anim_save(filename = "tab2-carbon-obj.gif")
+        gganimate::anim_save(filename = "tab2-Carbon-obj.gif")
       
       
       
@@ -2585,10 +2585,10 @@ bayesian_optimization <- function(
                  xmin = -Inf, xmax = area_sum_threshold, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Area sums, tab 2",
-             subtitle = "Green is the set of target-compatible area sums",
+             subtitle = "Green is the set of target-compatible Area sums",
              x = "Area sums",
              y = "Obj value")
-      ggsave("tab2-area-obj.png")
+      ggsave("tab2-Area-obj.png")
       # with animation
       all_rows <- data.frame(sumarea = rowSums(obj_inputs), obj = obj_outputs) |>
         unique()
@@ -2613,7 +2613,7 @@ bayesian_optimization <- function(
                  xmin = -Inf, xmax = area_sum_threshold, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Area sums, tab 2, {closest_state}",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Area sums",
              y = "Obj value")
       gganimate::animate(a,
@@ -2622,7 +2622,7 @@ bayesian_optimization <- function(
                          width = 1920,
                          height = 1080,
                          renderer = gifski_renderer()) |>
-        gganimate::anim_save(filename = "tab2-area-obj.gif")
+        gganimate::anim_save(filename = "tab2-Area-obj.gif")
       
       # Map
       # Target-compatible obj_inputs
@@ -2707,10 +2707,10 @@ bayesian_optimization <- function(
                  xmin = outcomes_to_maximize_sum_threshold_vector[1], xmax = Inf, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Carbon sums, tab 1",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Carbon sums",
              y = "Obj value")
-      ggsave("tab1-carbon-obj.png")
+      ggsave("tab1-Carbon-obj.png")
       # with animation
       all_rows <- data.frame(sumcarbon = rowSums(carbon_vectors), obj = obj_outputs) |>
         unique()
@@ -2735,7 +2735,7 @@ bayesian_optimization <- function(
                  xmin = outcomes_to_maximize_sum_threshold_vector[1], xmax = Inf, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Carbon sums, tab 1, {closest_state}",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Carbon sums",
              y = "Obj value")
       gganimate::animate(a,
@@ -2744,7 +2744,7 @@ bayesian_optimization <- function(
                          width = 1920,
                          height = 1080,
                          renderer = gifski_renderer()) |>
-        gganimate::anim_save(filename = "tab1-carbon-obj.gif")
+        gganimate::anim_save(filename = "tab1-Carbon-obj.gif")
       
       
       
@@ -2759,10 +2759,10 @@ bayesian_optimization <- function(
                  xmin = -Inf, xmax = area_sum_threshold, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Area sums, tab 1",
-             subtitle = "Green is the set of target-compatible area sums",
+             subtitle = "Green is the set of target-compatible Area sums",
              x = "Area sums",
              y = "Obj value")
-      ggsave("tab1-area-obj.png")
+      ggsave("tab1-Area-obj.png")
       # with animation
       all_rows <- data.frame(sumarea = rowSums(obj_inputs), obj = obj_outputs) |>
         unique()
@@ -2787,7 +2787,7 @@ bayesian_optimization <- function(
                  xmin = -Inf, xmax = area_sum_threshold, ymin = -Inf, ymax = Inf,
                  fill = "green", alpha = 0.2) +
         labs(title = "Obj value / Area sums, tab 1, {closest_state}",
-             subtitle = "Green is the set of target-compatible carbon sums",
+             subtitle = "Green is the set of target-compatible Carbon sums",
              x = "Area sums",
              y = "Obj value")
       gganimate::animate(a,
@@ -2796,20 +2796,20 @@ bayesian_optimization <- function(
                          width = 1920,
                          height = 1080,
                          renderer = gifski_renderer()) |>
-        gganimate::anim_save(filename = "tab1-area-obj.gif")
+        gganimate::anim_save(filename = "tab1-Area-obj.gif")
     }
     
     notif_msg <- rbind(
       "# strategies searched" = n + n * BAYESIAN_OPTIMIZATION_ITERATIONS,
       "# strategies evaluated" = (2 * BAYESIAN_OPTIMIZATION_ITERATIONS) * BAYESIAN_OPTIMIZATION_BATCH_SIZE + 10 * 6,
       "# locations" = number_of_locations,
-      "Σarea" = outcome$sum_area,
-      "area max" = area_sum_threshold,
-      "Σcarbon" = outcome$sum_carbon,
-      "carbon min" = outcomes_to_maximize_sum_threshold_vector["Carbon"],
+      "ΣArea" = outcome$sum_area,
+      "Area max" = area_sum_threshold,
+      "ΣCarbon" = outcome$sum_carbon,
+      "Carbon min" = outcomes_to_maximize_sum_threshold_vector["Carbon"],
       # "sum area_invalidness" = sum(diff_area_possible, na.rm = TRUE),
       "obj_value" = min(obj_outputs),
-      "preference weight area" = preference_weight_area,
+      "preference weight Area" = preference_weight_area,
       "preference weight outcomes to maximize" = toString(preference_weights_maximize),
       "# initial design points" = n,
       "smart REMBO" = RREMBO_SMART,

--- a/backend/functions.R
+++ b/backend/functions.R
@@ -1238,7 +1238,7 @@ observe_event_function_YearType <- function(choose = 1, # 1 for input$choose1, 2
 #  # SelectedSimMatBinary: convert SelectedSimMat without year of planting (binary)
 #  # SelectedSimMatYearOrSavedVec: matrix where the column where SavedVec=1 is replaced by 0 (planting at year 0)
 #  # SVMMAT: Matrix composed on SavedVec on every line (to do an OR later).
-#  # For the moment, the area does not change with year of planting.
+#  # For the moment, the Area does not change with year of planting.
 #  if (length(SavedVecYearLoc) == 1) {
 #    SelectedSimMat <- as.matrix(simul636YearLoc[, 1:length(SavedVecYearLoc)])
 #    SelectedSimMatBinary<- 1*(as.matrix(simul636YearLoc[, 1:length(SavedVecYearLoc)])!=(MAXYEAR+1))
@@ -1439,7 +1439,7 @@ outputmap_calculateMatsYearType <- function(input,
   # SelectedSimMatBinary: convert SelectedSimMat without year of planting (binary)
   # SelectedSimMatYearOrSavedVec: matrix where the column where SavedVec=1 is replaced by 0 (planting at year 0)
   # SVMMAT: Matrix composed on SavedVec on every line (to do an OR later).
-  # For the moment, the area does not change with year of planting.
+  # For the moment, the Area does not change with year of planting.
   if (length(SavedVecYearTypeLoc) == 1) {
     SelectedSimMat <- as.matrix(simul636YearTypeLoc$YEAR[, 1:length(SavedVecYearTypeLoc)])
     SelectedSimMatBinary<- 1*(as.matrix(simul636YearTypeLoc$YEAR[, 1:length(SavedVecYearTypeLoc)])!=(-1))
@@ -2451,16 +2451,16 @@ get_richness_from_fulltable <- function(strategy_vector, FullTable_arg = FullTab
   treespecie_vector <- strategy_vector[indices]
   
   small_fulltable_dt <- FullTable %>%
-    mutate(area = area_vector,
+    mutate(Area = area_vector,
            year = year_vector,
            treespecie = treespecie_vector) %>%
-    dplyr::select(area, year, treespecie, starts_with("Richness")) %>%
+    dplyr::select(Area, year, treespecie, starts_with("Richness")) %>%
     mutate(parcel_id = 1:nrow(FullTable)) |>
     setDT()
   
   # Melt the data table to convert from wide to long format
   melted_dt <- data.table::melt(small_fulltable_dt, 
-                                id.vars = c("area", "year", "treespecie", "parcel_id"), 
+                                id.vars = c("Area", "year", "treespecie", "parcel_id"), 
                                 measure.vars = grep("Richness", colnames(small_fulltable_dt), value = TRUE),
                                 variable.name = "column_name", 
                                 value.name = "richness")
@@ -2474,11 +2474,11 @@ get_richness_from_fulltable <- function(strategy_vector, FullTable_arg = FullTab
   
   # Remove rows where the column_name's tree specie is not the strategy treespecie
   # and where the planting year is not the strategy plantingyear
-  # and where we don't plant (area is 0)
+  # and where we don't plant (Area is 0)
   # and where plantingyear is 25
   melted_dt <- melted_dt[colname_treespecie == treespecie &
                            colname_plantingyear == year &
-                           area != 0 &
+                           Area != 0 &
                            colname_plantingyear != MAXYEAR + 1, ]
   
   # Sum richness by group
@@ -2583,7 +2583,7 @@ convert_bio_to_polygons_from_elicitor_and_merge_into_FullTable <- function(Elici
   intersection <- st_intersection(polygons_bio, polygons_jules)
   notif(paste(msg, "done"), max_limit_log_level = max_limit_log_level)
   
-  # Look at the area difference rowwise for mutate
+  # Look at the Area difference rowwise for mutate
   compute_difference_area <- function(geom1, geom2) {
     diff_geom <- st_difference(geom1, geom2)
     if (!is_empty(diff_geom)) {
@@ -2594,7 +2594,7 @@ convert_bio_to_polygons_from_elicitor_and_merge_into_FullTable <- function(Elici
   }
   
   # Calculate the proportion of areas (intersection / bio)
-  msg <- "Calculate the biodiversity values in shapefile cells, weighted by area ..."
+  msg <- "Calculate the biodiversity values in shapefile cells, weighted by Area ..."
   notif(msg, max_limit_log_level = max_limit_log_level)
   
   # We use progression bars inside and outside of functions, and this causes problems, local({}) solves them
@@ -2655,7 +2655,7 @@ convert_bio_to_polygons_from_elicitor_and_merge_into_FullTable <- function(Elici
         
         # Group by polygon_id_jules and average over parcels
         {
-          msg <- "Average biodiversities across (carbon, new) parcels"
+          msg <- "Average biodiversities across (Carbon, new) parcels"
           pb(message = msg)
           notif(paste("5/7", msg), max_limit_log_level = max_limit_log_level)
           invisible(.)
@@ -2684,7 +2684,7 @@ convert_bio_to_polygons_from_elicitor_and_merge_into_FullTable <- function(Elici
         ) %>% 
         
         {
-          msg <- "Compute area differences"
+          msg <- "Compute Area differences"
           pb(message = msg)
           notif(paste("6/7", msg), max_limit_log_level = max_limit_log_level)
           invisible(.)

--- a/backend/plumber.R
+++ b/backend/plumber.R
@@ -416,7 +416,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "info") {
       
       Uni <- unique(AllUnits)
       # units is the list of decision units
-      FullTab <- data.frame(extent = "NoExtent", x = rep(0, length(Uni)), y = rep(0, length(Uni)), area = rep(1, length(Uni)),
+      FullTab <- data.frame(extent = "NoExtent", x = rep(0, length(Uni)), y = rep(0, length(Uni)), Area = rep(1, length(Uni)),
                             Carbon_Mean_Scenario26_TreeSpecieConifers = rep(15, length(Uni)),
                             Carbon_SD_Scenario26_TreeSpecieConifers = rep(1, length(Uni)), 
                             Carbon_Mean_Scenario26_TreeSpecieDeciduous = rep(15, length(Uni)),
@@ -517,7 +517,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "info") {
       
       
       INTT <- st_intersection(st_make_valid(SELECTEDSquaresconvTab), st_make_valid(FullTableCopy))
-      INTT$area <- st_area(INTT) / 1e6
+      INTT$Area <- st_area(INTT) / 1e6
       
       # Bootstrap means and standard deviations (to avoid assumptions of independence)
       # As we have sum of Gaussians, we 
@@ -525,7 +525,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "info") {
       for (i in 1:length(FullTableCopy$geometry)) {
         SELLLines <- INTT$idPoly == i
         SELLSqs <- INTT$idSq[SELLLines]
-        SELLWeights <- INTT$area[SELLLines]
+        SELLWeights <- INTT$Area[SELLLines]
         #    SellWeightsArr <- t(matrix(SELLWeights, length(SELLWeights), NBSIMS))
         SellWeightsArr <- (matrix(SELLWeights, length(SELLWeights), (MAXYEAR+1)))
         
@@ -560,13 +560,13 @@ function(res, MAX_LIMIT_LOG_LEVEL = "info") {
           FullTable[i,paste0("Carbon_SD_Scenario26_TreeSpecieDeciduous_PlantingYear",0:MAXYEAR)]<-sqrt(colSums((SelJulesSDsYears85*SellWeightsArr)^2))
           
           
-          FullTable$area[i] <- sum(SELLWeights)
+          FullTable$Area[i] <- sum(SELLWeights)
           
           # } else if (length(SelJulesMeans) == 1) {
           #  SimuArr <- rnorm(NBSIMS, mean = SelJulesMeans, sd = SelJulesSDs)
           # FullTable$JulesMean[i] <- sum(colMeans(SimuArr * SellWeightsArr))
           #  FullTable$JulesSD[i] <- sd(rowSums(SimuArr * SellWeightsArr))
-          #  FullTable$area[i] <- sum(SELLWeights)
+          #  FullTable$Area[i] <- sum(SELLWeights)
         } else {
           FullTable$Carbon_Mean_Scenario26_TreeSpecieConifers[i] <- 0
           FullTable$Carbon_SD_Scenario26_TreeSpecieConifers[i] <- 0
@@ -582,7 +582,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "info") {
           FullTable[i,paste0("Carbon_SD_Scenario26_TreeSpecieDeciduous_PlantingYear",0:MAXYEAR)]<-(MAXYEAR+1)
           
           
-          FullTable$area[i] <- sum(SELLWeights)
+          FullTable$Area[i] <- sum(SELLWeights)
         }
       }
       
@@ -839,7 +839,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "info") {
       # if TRUE, use the new mapping from the zonotope, otherwise the original mapping with convex projection. default TRUE
       reverse = FALSE)
     RREMBO_HYPER_PARAMETERS <- RRembo_defaults(d = 6,
-                                               D = 3 * nrow(FullTable), # area + planting_year + tree_specie per parcel
+                                               D = 3 * nrow(FullTable), # Area + planting_year + tree_specie per parcel
                                                init = list(n = 100), budget = 100,
                                                control = RREMBO_CONTROL,
                                                max_limit_log_level = MAX_LIMIT_LOG_LEVEL)
@@ -929,7 +929,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "info") {
     # )
     # Add sliderInput("BioSliderSPECIE", "Average SPECIE % increase:", min = 0, max = 36, value = 25) for each specie
     
-    verticalLayout_params <- c(list(sliderInput("SliderMain", "Tree carbon stored (tonnes of CO2):", min = -1, max = 870, value = -1)),
+    verticalLayout_params <- c(list(sliderInput("SliderMain", "Tree Carbon stored (tonnes of CO2):", min = -1, max = 870, value = -1)),
                                lapply(SPECIES, function(x, fulltable, NAME_CONVERSION_ARG) {
                                  NAME_CONVERSION <- NAME_CONVERSION_ARG
                                  # max_specie <- round(max(fulltable[, paste0("BioMean_", x)]))
@@ -955,7 +955,7 @@ function(res, MAX_LIMIT_LOG_LEVEL = "info") {
                                                            step = 0.5)))
                                }, fulltable = FullTable, NAME_CONVERSION_ARG = NAME_CONVERSION),
                                list(sliderInput("AreaSlider", HTML("Area planted (km<sup>2</sup>)"), min = 0, max = 25, value = 15,step=1)),
-                               list(sliderInput("VisitsSlider", "Recreation (visits per month):", min = 0, max = 750, value = 400)))
+                               list(sliderInput("VisitsSlider", "Recreation (Visits per month):", min = 0, max = 750, value = 400)))
     #SPECIES<-c("All","Acanthis_cabaret","Birds","Alauda_arvensis")
     SliderNames<- c("SliderMain",
                     paste0("BioSlider", SPECIES),

--- a/code_for_danny.R
+++ b/code_for_danny.R
@@ -135,7 +135,7 @@ RREMBO_CONTROL <- list(
   # if TRUE, use the new mapping from the zonotope, otherwise the original mapping with convex projection. default TRUE
   reverse = FALSE)
 RREMBO_HYPER_PARAMETERS <- RRembo_defaults(d = 6,
-                                           D = 3 * nrow(FullTable), # area + planting_year + tree_specie per parcel
+                                           D = 3 * nrow(FullTable), # Area + planting_year + tree_specie per parcel
                                            init = list(n = 100), budget = 100,
                                            control = RREMBO_CONTROL,
                                            max_limit_log_level = MAX_LIMIT_LOG_LEVEL)
@@ -306,7 +306,7 @@ Implausibility <- function(x, targetLevel = -sqrt(alpha/(1-alpha)),
   if(outcomes$sum_area > area_sum_threshold){
     return((outcomes$sum_area-area_sum_threshold)/0.001)
   }
-  # Pre-fetch thresholds and SDs for carbon and visits
+  # Pre-fetch thresholds and SDs for Carbon and Visits
   thresholds <- outcomes_to_maximize_sum_threshold_vector[c("Carbon", "Visits")]
   sds_carbon_visits <- c(outcomes$sum_carbon_sd, outcomes$sum_visits_sd)
   val_carbon_visits <- c(outcomes$sum_carbon, outcomes$sum_visits)


### PR DESCRIPTION
Paul will handle the frontend when trying to update pc_1 and pc_2 when they have not been made available to the backend.
Food_Produced and Biodiversity were causing a few bugs, I took care of them.

Some places had "carbon", and others "Carbon". I didn' want to play cat and mouse with everywhere one or the other was used, so i did a search & replace for it. Now, we should always use capitalized variable names
More clearly, I replaced
visits->Visits
carbon->Carbon
area->Area
recreation->Recreation
carbon_sd->Carbon_sd
visits_sd->Visits_sd

and in convert_outcome_to_dt, str_to_title handles capitalizing the variable name.